### PR TITLE
Change export style from CommonJS to ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "build": "rm -rf build && rm -rf dist && npx waffle && tsc",
     "prepare": "tsc"
   },
+  "engines" : {
+    "node" : ">=14.13.1"
+  },
+  "engineStrict" : true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/axelarnetwork/axelar-local-dev.git"

--- a/src/networkUtils.ts
+++ b/src/networkUtils.ts
@@ -315,7 +315,7 @@ export const relay = async () => {
 };
 
 
-function listen(port: number, callback: (() => void) | undefined = undefined) {
+export function listen(port: number, callback: (() => void) | undefined = undefined) {
     if(!callback)
         callback = () => {
             logger.log(`Serving ${networks.length} networks on port ${port}`)
@@ -326,7 +326,7 @@ function listen(port: number, callback: (() => void) | undefined = undefined) {
 /**
  * @returns {Network}
  */
-async function createNetwork(options: NetworkOptions = {}) {
+export async function createNetwork(options: NetworkOptions = {}) {
     if(options.dbPath && fs.existsSync(options.dbPath + '/networkInfo.json')) {
         logger.log('this exists!');
         const info = require(options.dbPath + '/networkInfo.json');
@@ -399,7 +399,7 @@ async function createNetwork(options: NetworkOptions = {}) {
 /**
  * @returns {Network}
  */
-async function getNetwork(urlOrProvider: string | providers.Provider, info: NetworkInfo | undefined=undefined) {
+export async function getNetwork(urlOrProvider: string | providers.Provider, info: NetworkInfo | undefined=undefined) {
 
     if(!info)
         info = await httpGet(urlOrProvider + '/info') as NetworkInfo;
@@ -446,7 +446,7 @@ async function getNetwork(urlOrProvider: string | providers.Provider, info: Netw
 /**
  * @returns {[Network]}
  */
- async function getAllNetworks(url: string) {
+export async function getAllNetworks(url: string) {
     const n: number = parseInt(await httpGet(url + '/info') as string);
     for(let i=0;i<n;i++) {
         await getNetwork(url+'/'+i);
@@ -457,7 +457,7 @@ async function getNetwork(urlOrProvider: string | providers.Provider, info: Netw
 /**
  * @returns {Network}
  */
-async function setupNetwork (urlOrProvider: string | providers.Provider, options: NetworkSetup) {
+export async function setupNetwork (urlOrProvider: string | providers.Provider, options: NetworkSetup) {
     const chain = new Network();
     chain.name = options.name != null ? options.name : `Chain ${networks.length+1}`;
     chain.provider = typeof(urlOrProvider) === 'string' ? ethers.getDefaultProvider(urlOrProvider) : urlOrProvider;
@@ -485,7 +485,7 @@ async function setupNetwork (urlOrProvider: string | providers.Provider, options
     return chain;
 }
 
-async function stop(network: string | Network){
+export async function stop(network: string | Network){
     if(typeof(network) == 'string')
         network = networks.find(chain => chain.name == network)!;
     if(network.server != null)
@@ -493,7 +493,7 @@ async function stop(network: string | Network){
     networks.splice(networks.indexOf(network), 1);
 }
 
-async function stopAll() {
+export async function stopAll() {
     while(networks.length > 0) {
         await stop(networks[0]);
     }

--- a/src/networkUtils.ts
+++ b/src/networkUtils.ts
@@ -31,7 +31,6 @@ const ROLE_OWNER = 1;
 const ROLE_OPERATOR = 2;
 const fs = require('fs');
 
-
 const IAxelarGateway = require('../build/IAxelarGateway.json');
 const IAxelarExecutable = require('../build/IAxelarExecutable.json');
 const AxelarGasReceiver = require('../build/AxelarGasReceiver.json');
@@ -197,7 +196,7 @@ export const relay = async () => {
                         IAxelarExecutable.abi,
                         to!.relayerWallet,
                     );
-                    relayData.callContract[commandId].execution = 
+                    relayData.callContract[commandId].execution =
                         (await (await contract.execute(commandId, from.name, args.sender, args.payload)).wait()).transactionHash;
                 }),
             ));
@@ -295,7 +294,7 @@ export const relay = async () => {
                     if(log.amount - getFee(fromName, to, command.data[4]) != command.data[5]) return false;
                     return true;
                 });
-                
+
             if(!payed) continue;
             if(command.name == 'approveContractCall') {
                 const index = gasLogs.indexOf(payed);
@@ -303,7 +302,7 @@ export const relay = async () => {
             } else {
                 const index = gasLogsWithToken.indexOf(payed);
                 gasLogsWithToken.splice(index, 1);
-            }  
+            }
             try {
                 const cost = getGasPrice(fromName, to, payed.gasToken);
                 await command.post({gasLimit: payed.gasFeeAmount / cost});
@@ -510,10 +509,10 @@ async function stopAll() {
 const depositAddresses: any = {};
 
 export function getDepositAddress(
-    from: Network|string, 
-    to: Network|string, 
-    destinationAddress: string, 
-    symbol: string, 
+    from: Network|string,
+    to: Network|string,
+    destinationAddress: string,
+    symbol: string,
     port: number | undefined = undefined
 ) {
     if(typeof(from) != 'string')
@@ -586,26 +585,15 @@ export async function createAndExport(options: CreateLocalOptions = {}) {
     });
 }
 
-module.exports = {
-    networks: networks,
-    createAndExport,
-    createNetwork,
-    listen,
-    getNetwork,
-    getAllNetworks,
-    setupNetwork,
-    relay,
-    stop,
-    stopAll,
-    getFee,
-    getGasPrice,
-    getDepositAddress,
-    utils: {
-        deployContract,
-        defaultAccounts,
-        setJSON,
-        setLogger,
-    },
-    testnetInfo,
-    mainnetInfo,
+export const utils = {
+  deployContract,
+  defaultAccounts,
+  setJSON,
+  setLogger,
+}
+
+export {
+  networks,
+  testnetInfo,
+  mainnetInfo
 }


### PR DESCRIPTION
This PR fixes the issue that the Intellisense in Vscode cannot detect the function in `module.exports`, but it's able to detect an export in `ES module` style (e.g. `export const` or `export function`). 

Other files are already used `ES module` exports, `networkUtils.ts` is the only file that still uses `module.exports`, so it's better to keep it consistent.

The `ES module` export is supported since node `14.13.1`, so I've also set minimum node version to `14.13.1` in package.json.