### PR TITLE
Fixed numeric overflow with big amounts

### DIFF
--- a/src/networkUtils.ts
+++ b/src/networkUtils.ts
@@ -213,7 +213,7 @@ export const relay = async () => {
             const args: any = log.args;
             const fee = getFee(from, args.destinationChain, args.symbol);
             if (args.amount < fee) continue;
-            const amountOut = args.amount - fee;
+            const amountOut = args.amount.sub(fee);
             if (amountOut < 0) continue;
             const commandId = getLogID(from.name, log);
             relayData.callContractWithToken[commandId] = {


### PR DESCRIPTION
Small fix causing overflow when dealing with big amounts of token transfers. Amount was involved in number operators that seemed to be casting it out from BigNumber causing the following error:

Error: overflow [ See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-overflow ] (fault="overflow", operation="BigNumber.from", value=5999999999999000000, code=NUMERIC_FAULT, version=bignumber/5.6.2)