### PR TITLE
Fixed missing usage of gasLogsWithToken

### DIFF
--- a/src/relay.ts
+++ b/src/relay.ts
@@ -83,14 +83,14 @@ const updateGasLogs = async (from: Network, blockNumber: number) => {
     newGasLogs = (await from.gasReceiver.queryFilter(filter, from.lastRelayedBlock + 1, blockNumber))
         .map((log) => log.args)
     for(const gasLog of newGasLogs) {
-        gasLogs.push(gasLog);
+        gasLogsWithToken.push(gasLog);
     }
     filter = from.gasReceiver.filters.NativeGasPaidForContractCallWithToken();
     newGasLogs = (await from.gasReceiver.queryFilter(filter, from.lastRelayedBlock + 1, blockNumber)).map((log) => {
         return { ...log.args, gasToken: AddressZero };
     });
     for(const gasLog of newGasLogs) {
-        gasLogs.push(gasLog);
+        gasLogsWithToken.push(gasLog);
     }
 }
 


### PR DESCRIPTION
Gas paid for contract calls with token was being registered to the gasLogs array instead of the gasLogsWithToken array