### PR TITLE
Fixed number and BigInt precision

### DIFF
--- a/src/relay.ts
+++ b/src/relay.ts
@@ -141,6 +141,7 @@ const updateTokenSent = async (from: Network, blockNumber: number, relayData: Re
         const alias = getAliasFromSymbol(from.tokens, args.symbol);
         const fee = getFee(from, args.destinationChain, alias);
         if (args.amount <= fee) continue;
+        const amountOut = args.amount.sub(fee);
         const commandId = getLogID(from.name, log);
         const to = networks.find((chain: Network) => chain.name == args.destinationChain);
         const destinationTokenSymbol = to!.tokens[alias];
@@ -151,13 +152,13 @@ const updateTokenSent = async (from: Network, blockNumber: number, relayData: Re
             amountIn: args.amount,
             fee: fee,
             alias: alias,
-            amountOut: args.amount - fee,
+            amountOut: amountOut,
         };
         commands[args.destinationChain].push(
             new Command(
                 commandId,
                 'mintToken',
-                [destinationTokenSymbol, args.destinationAddress, BigInt(args.amount - fee)],
+                [destinationTokenSymbol, args.destinationAddress, amountOut],
                 ['string', 'address', 'uint256']
             )
         );


### PR DESCRIPTION
Minus operation between BigNumber and number and then casting to BigInt is giving wrong calculations. The amount used while finding this issue was 5999999999999000000 and substracting the fee was giving the wrong calculation of 5999999999997999104 instead of 5999999999998000000

Probably updateDepositAddresses will need adjustment as well since it's also mixing BigNumber and number in operations. Maybe best solution would be to change the getFee to return a BigNumber and change all operators accordingly