### PR TITLE
Fix/fork and export

### DIFF
--- a/src/exportUtils.ts
+++ b/src/exportUtils.ts
@@ -114,7 +114,7 @@ export async function forkAndExport(options: CloneLocalOptions = {}) {
         const network = await forkNetwork(chain, options.networkOptions);
 
 
-        const info = chain.getCloneInfo() as any;
+        const info = network.getCloneInfo() as any;
         info.rpc = `http://localhost:${options.port}/${i}`;
         info.tokenName = chain?.tokenName,
         info.tokenSymbol =  chain?.tokenSymbol,

--- a/src/exportUtils.ts
+++ b/src/exportUtils.ts
@@ -107,7 +107,7 @@ export async function forkAndExport(options: CloneLocalOptions = {}) {
     const chains =
         options.chains?.length == 0
             ? chainsRaw
-            : chainsRaw.filter((chain: any) => options.chains?.find((name) => name == chain.name) != null);
+            : chainsRaw.filter((chain: any) => options.chains?.find((name) => name.toLocaleLowerCase() == chain.name.toLocaleLowerCase()) != null);
 
     let i = 0;
     for (const chain of chains) {


### PR DESCRIPTION
Fix forkandExport functionality caused exception for undefined function on json object.
Add lowercase for chain filter which caused issue with inconsistent names between testnet and mainnet and local testnet on integration application (UI etc)
