### PR TITLE
fix: replace avalanche rpc

### DIFF
--- a/info/mainnet.json
+++ b/info/mainnet.json
@@ -15,7 +15,7 @@
   {
     "name": "Avalanche",
     "chainId": 43114,
-    "rpc": "https://api.avax.network/ext/bc/C/rpc",
+    "rpc": "https://avalanche-mainnet.infura.io/v3/a4812158fbab4a2aaa849e6f4a6dc605",
     "gateway": "0x5029C0EFf6C34351a0CEc334542cDb22c7928f78",
     "gasReceiver": "0xB53C693544363912D2A034f70D9d98808D5E192a",
     "constAddressDeployer": "0x617179a15fEAa53Fa82ae80b0fc3E85b7359a748",

--- a/test/test.js
+++ b/test/test.js
@@ -58,7 +58,7 @@ describe('create', () => {
             wallet: { accounts },
             chain: {
                 chainId: 3000,
-                netwrokId: 3000,
+                networkId: 3000,
             },
             logging: { quiet: true },
         });
@@ -323,8 +323,8 @@ describe('forking', async () => {
     it('should fork Avalanche mainnet', async () => {
         const chainName = 'Avalanche';
         const chains = mainnetInfo;
-        const avalance = chains.find((chain) => chain.name === chainName);
-        const chain = await forkNetwork(avalance, {
+        const avalanche = chains.find((chain) => chain.name === chainName);
+        const chain = await forkNetwork(avalanche, {
             ganacheOptions: {
                 fork: { deleteCache: true },
             },
@@ -335,7 +335,7 @@ describe('forking', async () => {
         const address = new Wallet(keccak256(toUtf8Bytes('random'))).address;
         await chain.giveToken(address, 'uusdc', 1234);
         expect(Number(await chain.usdc.balanceOf(address))).to.equal(1234);
-        expect(chain.gateway.address).to.equal(avalance.gateway);
+        expect(chain.gateway.address).to.equal(avalanche.gateway);
     });
     it('should fork Avalanche and Ethereum and send some USDC back and forth', async () => {
         const chains = mainnetInfo;


### PR DESCRIPTION
During testing the default avalanche RPC server is constantly
throttling request when forking avalanche mainnet.
This results in unexpected test failures I suggest using the infura RPC using the already provided project ID
from mainnet.
 