### PR TITLE
fix: error should not break relay function

### DIFF
--- a/src/exportUtils.ts
+++ b/src/exportUtils.ts
@@ -74,7 +74,7 @@ export async function createAndExport(options: CreateLocalOptions = {}) {
     interval = setInterval(async () => {
         if (relaying) return;
         relaying = true;
-        await relay();
+        await relay().catch(() => undefined);
         if (options.afterRelay) {
             options.afterRelay(evmRelayer.relayData);
             options.afterRelay(aptosRelayer.relayData);

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,4 @@ export {
     networks,
     testnetInfo,
     mainnetInfo,
-    createAndExport,
-    forkAndExport,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { createAndExport, forkAndExport } from './exportUtils';
 import { deployContract, defaultAccounts, setJSON, setLogger } from './utils';
 import { testnetInfo, mainnetInfo } from './info';
 import { networks } from './Network';
@@ -20,6 +19,7 @@ import {
 export * from './relay';
 export * from './aptos';
 export * from './utils';
+export * from './exportUtils';
 
 export const utils = {
     deployContract,


### PR DESCRIPTION
Catch all relay errors in the `createAndExports` function, so the relay function won't stop working when something goes wrong.