### PR TITLE
chore: remove reset gas events after relay

### DIFF
--- a/src/relay/Relayer.ts
+++ b/src/relay/Relayer.ts
@@ -30,7 +30,5 @@ export abstract class Relayer {
         await this.execute();
 
         this.commands = {};
-        this.contractCallGasEvents = [];
-        this.contractCallWithTokenGasEvents = [];
     }
 }


### PR DESCRIPTION
# Description

This PR removes resetting gas events after `relay` because it doesn't allow to pay the gas at the source chain for a 2-way call. 
For example, it prevents the `send-ack` example in `axelar-local-gmp-example` to work correctly. 