### PR TITLE
fix: add undefined check

### DIFF
--- a/src/relay/EvmRelayer.ts
+++ b/src/relay/EvmRelayer.ts
@@ -40,7 +40,7 @@ export class EvmRelayer extends Relayer {
     private async executeEvm() {
         for (const to of networks) {
             const commands = this.commands[to.name];
-            if (commands.length == 0) continue;
+            if (commands?.length == 0) continue;
 
             const execution = await this.executeEvmGateway(to, commands);
             await this.executeEvmExecutable(to, commands, execution);


### PR DESCRIPTION
In cases where the update function in the relay service
is early skipped we end up with an undefined commands structure
this PR add a simple check which fixed the issue.