### PR TITLE
chore: bump axelar-cgp-solidity to 4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@axelar-network/axelar-local-dev",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@axelar-network/axelar-local-dev",
-            "version": "1.4.4",
+            "version": "1.4.5",
             "license": "ISC",
             "dependencies": {
                 "@axelar-network/axelar-cgp-aptos": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@axelar-network/axelar-cgp-aptos": "^1.0.5",
                 "@axelar-network/axelar-cgp-near": "^1.0.0",
-                "@axelar-network/axelar-cgp-solidity": "github:axelarnetwork/axelar-cgp-solidity#feat/forecaller-service",
+                "@axelar-network/axelar-cgp-solidity": "^4.5.0",
                 "@axelar-network/axelar-gmp-sdk-solidity": "^3.2.1",
                 "aptos": "^1.3.16",
                 "ethers": "^5.6.5",
@@ -79,12 +79,9 @@
             }
         },
         "node_modules/@axelar-network/axelar-cgp-solidity": {
-            "version": "4.6.0",
-            "resolved": "git+ssh://git@github.com/axelarnetwork/axelar-cgp-solidity.git#b09e09b47d176bbef311693d4027b9f03f7dfe93",
-            "license": "ISC",
-            "dependencies": {
-                "@axelar-network/axelar-gmp-sdk-solidity": "^3.2.0"
-            },
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@axelar-network/axelar-cgp-solidity/-/axelar-cgp-solidity-4.5.0.tgz",
+            "integrity": "sha512-4F4rmHei0cmzeUR7/mW4Bap5rc/KlPV2crD9HA7HTRfl15mVcN6/3z8p+pAm9We6bOrQplNW9KBZ3HJFP3C1Gw==",
             "engines": {
                 "node": "^16.0.0 || ^18.0.0"
             }
@@ -21010,11 +21007,9 @@
             "integrity": "sha512-FzExtfKWzw5OLSMr/kpbm+fcCt94fb0JmypRtIWHs1trYZoNhTFlqNF9fIDLR30rcITixTV46DWSg3R5okiq1g=="
         },
         "@axelar-network/axelar-cgp-solidity": {
-            "version": "git+ssh://git@github.com/axelarnetwork/axelar-cgp-solidity.git#b09e09b47d176bbef311693d4027b9f03f7dfe93",
-            "from": "@axelar-network/axelar-cgp-solidity@github:axelarnetwork/axelar-cgp-solidity#feat/forecaller-service",
-            "requires": {
-                "@axelar-network/axelar-gmp-sdk-solidity": "^3.2.0"
-            }
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@axelar-network/axelar-cgp-solidity/-/axelar-cgp-solidity-4.5.0.tgz",
+            "integrity": "sha512-4F4rmHei0cmzeUR7/mW4Bap5rc/KlPV2crD9HA7HTRfl15mVcN6/3z8p+pAm9We6bOrQplNW9KBZ3HJFP3C1Gw=="
         },
         "@axelar-network/axelar-gmp-sdk-solidity": {
             "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@axelar-network/axelar-local-dev",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "description": "",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@axelar-network/axelar-cgp-aptos": "^1.0.5",
         "@axelar-network/axelar-cgp-near": "^1.0.0",
-        "@axelar-network/axelar-cgp-solidity": "github:axelarnetwork/axelar-cgp-solidity#feat/forecaller-service",
+        "@axelar-network/axelar-cgp-solidity": "^4.5.0",
         "@axelar-network/axelar-gmp-sdk-solidity": "^3.2.1",
         "aptos": "^1.3.16",
         "ethers": "^5.6.5",
@@ -48,6 +48,8 @@
     "devDependencies": {
         "@babel/eslint-parser": "^7.19.1",
         "@babel/preset-typescript": "^7.18.6",
+        "@typechain/ethers-v5": "^10.2.0",
+        "@typechain/hardhat": "^6.1.5",
         "@types/chai": "^4.3.4",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^29.2.1",
@@ -62,14 +64,12 @@
         "hardhat": "^2.9.9",
         "hardhat-gas-reporter": "^1.0.8",
         "jest": "^29.2.2",
+        "npm-run-all": "^4.1.5",
         "prettier": "^2.6.2",
         "prettier-plugin-solidity": "^1.0.0-beta.19",
         "solhint": "^3.3.7",
         "solidity-coverage": "^0.7.21",
         "ts-jest": "^29.0.3",
-        "@typechain/hardhat": "^6.1.5",
-        "@typechain/ethers-v5": "^10.2.0",
-        "npm-run-all": "^4.1.5",
         "typechain": "^8.1.1",
         "typescript": "^4.7.4"
     }


### PR DESCRIPTION
Blocker: needs [this PR](https://github.com/axelarnetwork/axelar-cgp-solidity/pull/160) to merge into main branch and release new version.