### PR TITLE
chore: update axelar-cgp-solidity and axelar-gmp-sdk-solidity version

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "packages": [
     "packages/*"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "@axelar-network/axelar-cgp-solidity": "^6.1.0"
+      },
       "devDependencies": {
         "lerna": "^6.6.1",
         "lerna-update-wizard": "^1.1.2"
@@ -41,20 +44,41 @@
       }
     },
     "node_modules/@axelar-network/axelar-cgp-solidity": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-cgp-solidity/-/axelar-cgp-solidity-5.0.0.tgz",
-      "integrity": "sha512-j/HshdS6MNZgEzqVgJq7gz9b1TgIwEr0QjmAUQMJWcGXk6EPp520+EWIFP+SomX3Zpu6p+Hg6+wf9giaLmrIQw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-cgp-solidity/-/axelar-cgp-solidity-6.1.0.tgz",
+      "integrity": "sha512-NHoJySnSujCmytYQIXtT760oPd4G8HSxH9qDhK6xd64soGLT6cnoMpZzQuhfonSqZRc/XWW7VJnvVX2AlgQ0Aw==",
       "dependencies": {
-        "@axelar-network/axelar-gmp-sdk-solidity": "^4.0.0"
+        "@axelar-network/axelar-gmp-sdk-solidity": "^5.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0"
+        "node": ">=16"
+      }
+    },
+    "node_modules/@axelar-network/axelar-chains-config": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-chains-config/-/axelar-chains-config-0.1.0.tgz",
+      "integrity": "sha512-ZUEiye0baTk3WmFlLk96I3gjR+eywI0cFRGCJlG8U/JytPRb3+vHqOwh6kSQenkqtCULXDkKTQzige5mCRs2Kw==",
+      "dependencies": {
+        "fs-extra": "^11.1.1"
+      }
+    },
+    "node_modules/@axelar-network/axelar-chains-config/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/@axelar-network/axelar-gmp-sdk-solidity": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-4.0.2.tgz",
-      "integrity": "sha512-AiO6ez3A42Kh8PTtoo3R8gqoZzBKGFZRogTQBy0GXm7ZMAUdAbHcDPbQwBwjOw8+fxVNSpLTvXxsAR2FUq85GQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-5.3.0.tgz",
+      "integrity": "sha512-gLAslEu7qamwUic2sTrXBqyY9kKI0jccSeKCleK6PZ3rGuHIDHvaM3Ap75oO6nYmp++i9MqxWlf+MJJk5f0IQA==",
       "engines": {
         "node": ">=16"
       }
@@ -65,6 +89,10 @@
     },
     "node_modules/@axelar-network/axelar-local-dev-aptos": {
       "resolved": "packages/axelar-local-dev-aptos",
+      "link": true
+    },
+    "node_modules/@axelar-network/axelar-local-dev-cosmos": {
+      "resolved": "packages/axelar-local-dev-cosmos",
       "link": true
     },
     "node_modules/@axelar-network/axelar-local-dev-near": {
@@ -741,6 +769,179 @@
         "@chainsafe/as-sha256": "^0.3.1",
         "@chainsafe/persistent-merkle-tree": "^0.4.2",
         "case": "^1.6.3"
+      }
+    },
+    "node_modules/@confio/ics23": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@confio/ics23/-/ics23-0.6.8.tgz",
+      "integrity": "sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==",
+      "dependencies": {
+        "@noble/hashes": "^1.0.0",
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/@cosmjs/amino": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.1.tgz",
+      "integrity": "sha512-kkB9IAkNEUFtjp/uwHv95TgM8VGJ4VWfZwrTyLNqBDD1EpSX2dsNrmUe7k8OMPzKlZUFcKmD4iA0qGvIwzjbGA==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.31.1",
+        "@cosmjs/encoding": "^0.31.1",
+        "@cosmjs/math": "^0.31.1",
+        "@cosmjs/utils": "^0.31.1"
+      }
+    },
+    "node_modules/@cosmjs/crypto": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.1.tgz",
+      "integrity": "sha512-4R/SqdzdVzd4E5dpyEh1IKm5GbTqwDogutyIyyb1bcOXiX/x3CrvPI9Tb4WSIMDLvlb5TVzu2YnUV51Q1+6mMA==",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.31.1",
+        "@cosmjs/math": "^0.31.1",
+        "@cosmjs/utils": "^0.31.1",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.4",
+        "libsodium-wrappers-sumo": "^0.7.11"
+      }
+    },
+    "node_modules/@cosmjs/encoding": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.1.tgz",
+      "integrity": "sha512-IuxP6ewwX6vg9sUJ8ocJD92pkerI4lyG8J5ynAM3NaX3q+n+uMoPRSQXNeL9bnlrv01FF1kIm8if/f5F7ZPtkA==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "node_modules/@cosmjs/json-rpc": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.31.1.tgz",
+      "integrity": "sha512-gIkCj2mUDHAxvmJnHtybXtMLZDeXrkDZlujjzhvJlWsIuj1kpZbKtYqh+eNlfwhMkMMAlQa/y4422jDmizW+ng==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.31.1",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/math": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.1.tgz",
+      "integrity": "sha512-kiuHV6m6DSB8/4UV1qpFhlc4ul8SgLXTGRlYkYiIIP4l0YNeJ+OpPYaOlEgx4Unk2mW3/O2FWYj7Jc93+BWXng==",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
+    "node_modules/@cosmjs/proto-signing": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.31.1.tgz",
+      "integrity": "sha512-hipbBVrssPu+jnmRzQRP5hhS/mbz2nU7RvxG/B1ZcdNhr1AtZC5DN09OTUoEpMSRgyQvScXmk/NTbyf+xmCgYg==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.31.1",
+        "@cosmjs/crypto": "^0.31.1",
+        "@cosmjs/encoding": "^0.31.1",
+        "@cosmjs/math": "^0.31.1",
+        "@cosmjs/utils": "^0.31.1",
+        "cosmjs-types": "^0.8.0",
+        "long": "^4.0.0"
+      }
+    },
+    "node_modules/@cosmjs/socket": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.31.1.tgz",
+      "integrity": "sha512-XTtEr+x3WGbqkzoGX0sCkwVqf5n+bBqDwqNgb+DWaBABQxHVRuuainrTVp0Yc91D3Iy2twLQzeBA9OrRxDSerw==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.31.1",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^7",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/socket/node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/@cosmjs/stargate": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.31.1.tgz",
+      "integrity": "sha512-TqOJZYOH5W3sZIjR6949GfjhGXO3kSHQ3/KmE+SuKyMMmQ5fFZ45beawiRtVF0/CJg5RyPFyFGJKhb1Xxv3Lcg==",
+      "dependencies": {
+        "@confio/ics23": "^0.6.8",
+        "@cosmjs/amino": "^0.31.1",
+        "@cosmjs/encoding": "^0.31.1",
+        "@cosmjs/math": "^0.31.1",
+        "@cosmjs/proto-signing": "^0.31.1",
+        "@cosmjs/stream": "^0.31.1",
+        "@cosmjs/tendermint-rpc": "^0.31.1",
+        "@cosmjs/utils": "^0.31.1",
+        "cosmjs-types": "^0.8.0",
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.3",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/stream": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.31.1.tgz",
+      "integrity": "sha512-xsIGD9bpBvYYZASajCyOevh1H5pDdbOWmvb4UwGZ78doGVz3IC3Kb9BZKJHIX2fjq9CMdGVJHmlM+Zp5aM8yZA==",
+      "dependencies": {
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/tendermint-rpc": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.31.1.tgz",
+      "integrity": "sha512-KX+wwi725sSePqIxfMPPOqg+xTETV8BHGOBhRhCZXEl5Fq48UlXXq3/yG1sn7K67ADC0kqHqcCF41Wn1GxNNPA==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.31.1",
+        "@cosmjs/encoding": "^0.31.1",
+        "@cosmjs/json-rpc": "^0.31.1",
+        "@cosmjs/math": "^0.31.1",
+        "@cosmjs/socket": "^0.31.1",
+        "@cosmjs/stream": "^0.31.1",
+        "@cosmjs/utils": "^0.31.1",
+        "axios": "^0.21.2",
+        "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/tendermint-rpc/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/@cosmjs/utils": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.1.tgz",
+      "integrity": "sha512-n4Se1wu4GnKwztQHNFfJvUeWcpvx3o8cWhSbNs9JQShEuB3nv3R5lqFBtDCgHZF/emFQAP+ZjF8bTfCs9UBGhA=="
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -5144,6 +5345,60 @@
         "node": ">=14"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@scure/base": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.2.tgz",
@@ -6021,6 +6276,30 @@
         "web3": "1.7.4"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@tufjs/canonical-json": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-1.0.0.tgz",
@@ -6297,6 +6576,11 @@
       "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
       "dev": true
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
     "node_modules/@types/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6324,8 +6608,7 @@
     "node_modules/@types/node": {
       "version": "18.16.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.5.tgz",
-      "integrity": "sha512-seOA34WMo9KB+UA78qaJoCO20RJzZGVXQ5Sh6FWu0g/hfT44nKXnej3/tCQl7FL97idFpBhisLYCTB50S0EirA==",
-      "devOptional": true
+      "integrity": "sha512-seOA34WMo9KB+UA78qaJoCO20RJzZGVXQ5Sh6FWu0g/hfT44nKXnej3/tCQl7FL97idFpBhisLYCTB50S0EirA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -6865,6 +7148,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -7065,6 +7357,12 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -7524,7 +7822,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9156,6 +9453,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmjs-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
+      "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
+      "dependencies": {
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -9210,6 +9516,12 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -9495,7 +9807,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
       "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
-      "dev": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -9655,6 +9966,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/docker-compose": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.2.tgz",
+      "integrity": "sha512-2/WLvA7UZ6A2LDLQrYW0idKipmNBWhtfvrn2yzjC5PnHDzuFVj1zAZN6MJxVMKP0zZH8uzAK6OwVZYHGuyCmTw==",
+      "dev": true,
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-compose/node_modules/yaml": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/doctrine": {
@@ -12287,8 +12619,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -12947,7 +13278,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
       "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -13344,7 +13674,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
-      "dev": true,
       "dependencies": {
         "define-properties": "^1.1.3"
       },
@@ -13690,7 +14019,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -13720,7 +14048,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.1"
       },
@@ -13744,7 +14071,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -18176,6 +18502,19 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/libsodium-sumo": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.11.tgz",
+      "integrity": "sha512-bY+7ph7xpk51Ez2GbE10lXAQ5sJma6NghcIDaSPbM/G9elfrjLa0COHl/7P6Wb/JizQzl5UQontOOP1z0VwbLA=="
+    },
+    "node_modules/libsodium-wrappers-sumo": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.11.tgz",
+      "integrity": "sha512-DGypHOmJbB1nZn89KIfGOAkDgfv5N6SBGC3Qvmy/On0P0WD1JQvNRS/e3UL3aFF+xC0m+MYz5M+MnRnK2HMrKQ==",
+      "dependencies": {
+        "libsodium-sumo": "^0.7.11"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
@@ -18344,6 +18683,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/loupe": {
       "version": "2.3.6",
@@ -20961,7 +21305,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -22209,6 +22552,31 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
+    "node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
     "node_modules/protocols": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
@@ -22826,6 +23194,11 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/readonly-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz",
+      "integrity": "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ=="
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
@@ -25085,6 +25458,14 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/symbol-observable": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/sync-request": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
@@ -26932,6 +27313,58 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -27509,6 +27942,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
@@ -29370,6 +29809,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/xstream": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/xstream/-/xstream-11.14.0.tgz",
+      "integrity": "sha512-1bLb+kKKtKPbgTK6i/BaoAn03g47PpFstlbe1BA+y3pNS/LfvcaghS5BFf9+EE1J+KwSQsEpfJvFN5GqFtiNmw==",
+      "dependencies": {
+        "globalthis": "^1.0.1",
+        "symbol-observable": "^2.0.3"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -29533,6 +29981,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -29550,8 +30007,9 @@
       "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@axelar-network/axelar-cgp-solidity": "^5.0.0",
-        "@axelar-network/axelar-gmp-sdk-solidity": "^4.0.2",
+        "@axelar-network/axelar-cgp-solidity": "^6.1.0",
+        "@axelar-network/axelar-chains-config": "^0.1.0",
+        "@axelar-network/axelar-gmp-sdk-solidity": "^5.3.0",
         "ethers": "^5.6.5",
         "fs-extra": "^10.1.0",
         "ganache": "^7.1.0",
@@ -29600,6 +30058,19 @@
         "@axelar-network/axelar-cgp-aptos": "^1.0.5",
         "@axelar-network/axelar-local-dev": "2.1.0",
         "aptos": "1.3.16"
+      }
+    },
+    "packages/axelar-local-dev-cosmos": {
+      "name": "@axelar-network/axelar-local-dev-cosmos",
+      "version": "2.1.0",
+      "license": "ISC",
+      "dependencies": {
+        "@axelar-network/axelar-local-dev": "2.1.0",
+        "@cosmjs/stargate": "^0.31.1"
+      },
+      "devDependencies": {
+        "docker-compose": "^0.24.2",
+        "ts-node": "^10.9.1"
       }
     },
     "packages/axelar-local-dev-near": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "@axelar-network/axelar-cgp-solidity": "^6.1.0"
-      },
       "devDependencies": {
         "lerna": "^6.6.1",
         "lerna-update-wizard": "^1.1.2"
@@ -89,10 +86,6 @@
     },
     "node_modules/@axelar-network/axelar-local-dev-aptos": {
       "resolved": "packages/axelar-local-dev-aptos",
-      "link": true
-    },
-    "node_modules/@axelar-network/axelar-local-dev-cosmos": {
-      "resolved": "packages/axelar-local-dev-cosmos",
       "link": true
     },
     "node_modules/@axelar-network/axelar-local-dev-near": {
@@ -771,162 +764,13 @@
         "case": "^1.6.3"
       }
     },
-    "node_modules/@confio/ics23": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@confio/ics23/-/ics23-0.6.8.tgz",
-      "integrity": "sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==",
-      "dependencies": {
-        "@noble/hashes": "^1.0.0",
-        "protobufjs": "^6.8.8"
-      }
-    },
-    "node_modules/@cosmjs/amino": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.1.tgz",
-      "integrity": "sha512-kkB9IAkNEUFtjp/uwHv95TgM8VGJ4VWfZwrTyLNqBDD1EpSX2dsNrmUe7k8OMPzKlZUFcKmD4iA0qGvIwzjbGA==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1"
-      }
-    },
-    "node_modules/@cosmjs/crypto": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.1.tgz",
-      "integrity": "sha512-4R/SqdzdVzd4E5dpyEh1IKm5GbTqwDogutyIyyb1bcOXiX/x3CrvPI9Tb4WSIMDLvlb5TVzu2YnUV51Q1+6mMA==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@cosmjs/encoding": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.1.tgz",
-      "integrity": "sha512-IuxP6ewwX6vg9sUJ8ocJD92pkerI4lyG8J5ynAM3NaX3q+n+uMoPRSQXNeL9bnlrv01FF1kIm8if/f5F7ZPtkA==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@cosmjs/json-rpc": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.31.1.tgz",
-      "integrity": "sha512-gIkCj2mUDHAxvmJnHtybXtMLZDeXrkDZlujjzhvJlWsIuj1kpZbKtYqh+eNlfwhMkMMAlQa/y4422jDmizW+ng==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.31.1",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@cosmjs/math": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.1.tgz",
-      "integrity": "sha512-kiuHV6m6DSB8/4UV1qpFhlc4ul8SgLXTGRlYkYiIIP4l0YNeJ+OpPYaOlEgx4Unk2mW3/O2FWYj7Jc93+BWXng==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@cosmjs/proto-signing": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.31.1.tgz",
-      "integrity": "sha512-hipbBVrssPu+jnmRzQRP5hhS/mbz2nU7RvxG/B1ZcdNhr1AtZC5DN09OTUoEpMSRgyQvScXmk/NTbyf+xmCgYg==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.31.1",
-        "@cosmjs/crypto": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
-        "cosmjs-types": "^0.8.0",
-        "long": "^4.0.0"
-      }
-    },
-    "node_modules/@cosmjs/socket": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.31.1.tgz",
-      "integrity": "sha512-XTtEr+x3WGbqkzoGX0sCkwVqf5n+bBqDwqNgb+DWaBABQxHVRuuainrTVp0Yc91D3Iy2twLQzeBA9OrRxDSerw==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.31.1",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@cosmjs/socket/node_modules/isomorphic-ws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "peerDependencies": {
-        "ws": "*"
-      }
-    },
-    "node_modules/@cosmjs/stargate": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.31.1.tgz",
-      "integrity": "sha512-TqOJZYOH5W3sZIjR6949GfjhGXO3kSHQ3/KmE+SuKyMMmQ5fFZ45beawiRtVF0/CJg5RyPFyFGJKhb1Xxv3Lcg==",
-      "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/proto-signing": "^0.31.1",
-        "@cosmjs/stream": "^0.31.1",
-        "@cosmjs/tendermint-rpc": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
-        "cosmjs-types": "^0.8.0",
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.3",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@cosmjs/stream": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.31.1.tgz",
-      "integrity": "sha512-xsIGD9bpBvYYZASajCyOevh1H5pDdbOWmvb4UwGZ78doGVz3IC3Kb9BZKJHIX2fjq9CMdGVJHmlM+Zp5aM8yZA==",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.31.1.tgz",
-      "integrity": "sha512-KX+wwi725sSePqIxfMPPOqg+xTETV8BHGOBhRhCZXEl5Fq48UlXXq3/yG1sn7K67ADC0kqHqcCF41Wn1GxNNPA==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/json-rpc": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/socket": "^0.31.1",
-        "@cosmjs/stream": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
-        "axios": "^0.21.2",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@cosmjs/tendermint-rpc/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/@cosmjs/utils": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.1.tgz",
-      "integrity": "sha512-n4Se1wu4GnKwztQHNFfJvUeWcpvx3o8cWhSbNs9JQShEuB3nv3R5lqFBtDCgHZF/emFQAP+ZjF8bTfCs9UBGhA=="
-    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -939,6 +783,8 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -5345,60 +5191,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
     "node_modules/@scure/base": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.2.tgz",
@@ -6280,25 +6072,33 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
       "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "1.0.0",
@@ -6576,11 +6376,6 @@
       "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
       "dev": true
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
-    },
     "node_modules/@types/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6608,7 +6403,8 @@
     "node_modules/@types/node": {
       "version": "18.16.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.5.tgz",
-      "integrity": "sha512-seOA34WMo9KB+UA78qaJoCO20RJzZGVXQ5Sh6FWu0g/hfT44nKXnej3/tCQl7FL97idFpBhisLYCTB50S0EirA=="
+      "integrity": "sha512-seOA34WMo9KB+UA78qaJoCO20RJzZGVXQ5Sh6FWu0g/hfT44nKXnej3/tCQl7FL97idFpBhisLYCTB50S0EirA==",
+      "devOptional": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -7153,6 +6949,8 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7362,7 +7160,9 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -7822,6 +7622,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9453,15 +9254,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cosmjs-types": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
-      "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
-      }
-    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -9521,7 +9313,9 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -9807,6 +9601,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
       "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+      "dev": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -9966,27 +9761,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/docker-compose": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.2.tgz",
-      "integrity": "sha512-2/WLvA7UZ6A2LDLQrYW0idKipmNBWhtfvrn2yzjC5PnHDzuFVj1zAZN6MJxVMKP0zZH8uzAK6OwVZYHGuyCmTw==",
-      "dev": true,
-      "dependencies": {
-        "yaml": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/docker-compose/node_modules/yaml": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
-      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/doctrine": {
@@ -12619,7 +12393,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -13278,6 +13053,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
       "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -13674,6 +13450,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
       "dependencies": {
         "define-properties": "^1.1.3"
       },
@@ -14019,6 +13796,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -14048,6 +13826,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.1"
       },
@@ -14071,6 +13850,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -18502,19 +18282,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/libsodium-sumo": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.11.tgz",
-      "integrity": "sha512-bY+7ph7xpk51Ez2GbE10lXAQ5sJma6NghcIDaSPbM/G9elfrjLa0COHl/7P6Wb/JizQzl5UQontOOP1z0VwbLA=="
-    },
-    "node_modules/libsodium-wrappers-sumo": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.11.tgz",
-      "integrity": "sha512-DGypHOmJbB1nZn89KIfGOAkDgfv5N6SBGC3Qvmy/On0P0WD1JQvNRS/e3UL3aFF+xC0m+MYz5M+MnRnK2HMrKQ==",
-      "dependencies": {
-        "libsodium-sumo": "^0.7.11"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
@@ -18683,11 +18450,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/loupe": {
       "version": "2.3.6",
@@ -21305,6 +21067,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -22552,31 +22315,6 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
-    "node_modules/protobufjs": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
     "node_modules/protocols": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
@@ -23194,11 +22932,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/readonly-date": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz",
-      "integrity": "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ=="
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
@@ -25458,14 +25191,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/symbol-observable": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
-      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/sync-request": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
@@ -27318,6 +27043,8 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -27361,6 +27088,8 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -27948,7 +27677,9 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -29809,15 +29540,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/xstream": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/xstream/-/xstream-11.14.0.tgz",
-      "integrity": "sha512-1bLb+kKKtKPbgTK6i/BaoAn03g47PpFstlbe1BA+y3pNS/LfvcaghS5BFf9+EE1J+KwSQsEpfJvFN5GqFtiNmw==",
-      "dependencies": {
-        "globalthis": "^1.0.1",
-        "symbol-observable": "^2.0.3"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -29986,6 +29708,8 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -30004,7 +29728,7 @@
     },
     "packages/axelar-local-dev": {
       "name": "@axelar-network/axelar-local-dev",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@axelar-network/axelar-cgp-solidity": "^6.1.0",
@@ -30052,17 +29776,18 @@
     },
     "packages/axelar-local-dev-aptos": {
       "name": "@axelar-network/axelar-local-dev-aptos",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@axelar-network/axelar-cgp-aptos": "^1.0.5",
-        "@axelar-network/axelar-local-dev": "2.1.0",
+        "@axelar-network/axelar-local-dev": "2.1.1",
         "aptos": "1.3.16"
       }
     },
     "packages/axelar-local-dev-cosmos": {
       "name": "@axelar-network/axelar-local-dev-cosmos",
       "version": "2.1.0",
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "@axelar-network/axelar-local-dev": "2.1.0",
@@ -30075,19 +29800,19 @@
     },
     "packages/axelar-local-dev-near": {
       "name": "@axelar-network/axelar-local-dev-near",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@axelar-network/axelar-cgp-near": "^1.0.0",
-        "@axelar-network/axelar-local-dev": "2.1.0"
+        "@axelar-network/axelar-local-dev": "2.1.1"
       }
     },
     "packages/axelar-local-dev-sui": {
       "name": "@axelar-network/axelar-local-dev-sui",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
-        "@axelar-network/axelar-local-dev": "2.1.0",
+        "@axelar-network/axelar-local-dev": "2.1.1",
         "@mysten/sui.js": "^0.41.0"
       }
     }

--- a/packages/axelar-local-dev-aptos/__tests__/aptos.spec.ts
+++ b/packages/axelar-local-dev-aptos/__tests__/aptos.spec.ts
@@ -3,9 +3,8 @@ import { AptosNetwork, AptosRelayer, createAptosNetwork } from '..';
 import fs from 'fs';
 import path from 'path';
 import { ethers } from 'ethers';
-import { Network, createNetwork, deployContract, relay, setLogger } from '@axelar-network/axelar-local-dev';
+import { Network, createNetwork, deployContract, relay, setLogger, EvmRelayer } from '@axelar-network/axelar-local-dev';
 import HelloWorld from '../artifacts/__tests__/contracts/HelloWorld.sol/HelloWorld.json';
-import { EvmRelayer } from '@axelar-network/axelar-local-dev/dist/relay/EvmRelayer';
 const { keccak256, toUtf8Bytes } = ethers.utils;
 
 setLogger(() => undefined);

--- a/packages/axelar-local-dev-aptos/__tests__/aptos.spec.ts
+++ b/packages/axelar-local-dev-aptos/__tests__/aptos.spec.ts
@@ -1,5 +1,5 @@
 import { HexString, TxnBuilderTypes } from 'aptos';
-import { AptosNetwork, AptosRelayer, createAptosNetwork, findNodeModulesPath } from '..';
+import { AptosNetwork, AptosRelayer, createAptosNetwork } from '..';
 import fs from 'fs';
 import path from 'path';
 import { ethers } from 'ethers';

--- a/packages/axelar-local-dev-aptos/__tests__/utils.spec.ts
+++ b/packages/axelar-local-dev-aptos/__tests__/utils.spec.ts
@@ -1,5 +1,6 @@
-import { findNodeModulesPath } from '..';
+import { findNodeModulesPath, findAxelarFramework } from '..';
 import path from 'path';
+import fs from 'fs';
 
 describe('utils', () => {
     it('should be able to find base `node_modules` path when the current dir is deep inside the node_modules folder', () => {
@@ -10,5 +11,14 @@ describe('utils', () => {
     it('should be able to find base `node_modules` path when the current dir is deeper, but it does not inside the node_modules folder', () => {
         const path = findNodeModulesPath(__dirname);
         expect(path.endsWith('node_modules')).toBeTruthy();
+    });
+
+    it('should be able to find `axelar_framework` path when the current dir is deep inside the node_modules folder', () => {
+        const frameworkPath = findAxelarFramework(
+            path.join(__dirname, '..', '..', '..', '/node_modules/@axelar-network/axelar-local-dev/dist'),
+        );
+
+        const files = fs.readdirSync(frameworkPath);
+        expect(files.indexOf('package-metadata.bcs') > -1);
     });
 });

--- a/packages/axelar-local-dev-aptos/package.json
+++ b/packages/axelar-local-dev-aptos/package.json
@@ -12,7 +12,7 @@
         "test": "jest",
         "build-ts": "tsc",
         "build-aptos": "bash ./__tests__/modules/build.sh",
-        "build-contract": "hardhat compile",
+        "build-contract": "hardhat clean && hardhat compile",
         "build": "run-s clean build-ts build-contract build-aptos",
         "clean": "rm -rf src/types dist artifacts",
         "prettier": "prettier --write 'src/**/*.ts'"

--- a/packages/axelar-local-dev-aptos/package.json
+++ b/packages/axelar-local-dev-aptos/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@axelar-network/axelar-local-dev-aptos",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "main": "dist/index.js",
     "files": [
         "dist/",
@@ -19,7 +19,7 @@
     },
     "dependencies": {
         "@axelar-network/axelar-cgp-aptos": "^1.0.5",
-        "@axelar-network/axelar-local-dev": "2.1.0",
+        "@axelar-network/axelar-local-dev": "2.1.1",
         "aptos": "1.3.16"
     },
     "author": "",

--- a/packages/axelar-local-dev-aptos/src/AptosNetwork.ts
+++ b/packages/axelar-local-dev-aptos/src/AptosNetwork.ts
@@ -2,7 +2,7 @@ import { AptosAccount, AptosClient, CoinClient, HexString, TxnBuilderTypes, BCS,
 import fs from 'fs';
 import path from 'path';
 import { sha3_256 as sha3Hash } from '@noble/hashes/sha3';
-import { findNodeModulesPath } from './utils';
+import { findAxelarFramework } from './utils';
 
 declare type EntryFunctionPayload = {
     function: string;
@@ -80,7 +80,7 @@ export class AptosNetwork extends AptosClient {
             txHash = await this.publishPackage(
                 this.owner,
                 new HexString(packageMetadata.toString('hex')).toUint8Array(),
-                moduleDatas.map((moduleData: any) => new TxnBuilderTypes.Module(new HexString(moduleData.toString('hex')).toUint8Array()))
+                moduleDatas.map((moduleData: any) => new TxnBuilderTypes.Module(new HexString(moduleData.toString('hex')).toUint8Array())),
             );
         }
 
@@ -96,8 +96,7 @@ export class AptosNetwork extends AptosClient {
     }
 
     deployAxelarFrameworkModules() {
-        const nodeModulesPath = findNodeModulesPath(__dirname);
-        const modulePath = path.join(nodeModulesPath, '@axelar-network/axelar-cgp-aptos/aptos/modules/axelar/build/AxelarFramework');
+        const modulePath = findAxelarFramework(__dirname);
         return this.deploy(modulePath, ['axelar_gas_service.mv', 'address_utils.mv', 'gateway.mv'], '0x1234');
     }
 
@@ -121,7 +120,7 @@ export class AptosNetwork extends AptosClient {
             this.resourceAddress,
             `${this.resourceAddress}::gateway::OutgoingContractCallsState`,
             'events',
-            _options
+            _options,
         );
     }
 
@@ -131,7 +130,7 @@ export class AptosNetwork extends AptosClient {
             this.resourceAddress,
             `${this.resourceAddress}::axelar_gas_service::GasServiceEventStore`,
             'native_gas_paid_for_contract_call_events',
-            _options
+            _options,
         );
     }
 
@@ -140,7 +139,7 @@ export class AptosNetwork extends AptosClient {
         sourceChain: string,
         sourceAddress: string,
         destinationAddress: string,
-        payloadHash: Uint8Array
+        payloadHash: Uint8Array,
     ) {
         const tx = await this.submitTransactionAndWait(this.owner.address(), {
             function: `${this.resourceAddress}::gateway::approve_contract_call`,

--- a/packages/axelar-local-dev-aptos/src/utils.ts
+++ b/packages/axelar-local-dev-aptos/src/utils.ts
@@ -8,14 +8,23 @@ export const getAptosLogID = (chain: string, event: any) => {
     return ethers.utils.id(chain + ':' + event.guid.account_address + ':' + event.version + ':' + event.sequence_number);
 };
 
-export const findNodeModulesPath = (currentDir: string) => {
-    let pathfinder: string = currentDir;
-    while (!pathfinder.endsWith('node_modules')) {
-        pathfinder = path.join(pathfinder, '..');
-        const dirs = fs.readdirSync(pathfinder);
-        if (dirs.indexOf('node_modules') > -1) {
-            pathfinder += '/node_modules';
+export const findAxelarFramework = (currentDir: string): string => {
+    const node_module = findNodeModulesPath(currentDir);
+    const dirs = fs.readdirSync(node_module);
+    if (dirs.indexOf('@axelar-network') > -1) {
+        const axelarDirs = fs.readdirSync(path.join(node_module, '@axelar-network'));
+        if (axelarDirs.indexOf('axelar-cgp-aptos') > -1) {
+            return path.join(node_module, '@axelar-network', 'axelar-cgp-aptos', 'aptos', 'modules', 'axelar', 'build', 'AxelarFramework');
         }
     }
-    return pathfinder;
+
+    return findAxelarFramework(path.join(currentDir, '..'));
+};
+
+export const findNodeModulesPath = (currentDir: string): string => {
+    const dirs = fs.readdirSync(currentDir);
+    if (dirs.indexOf('node_modules') > -1) {
+        return path.join(currentDir, 'node_modules');
+    }
+    return findNodeModulesPath(path.join(currentDir, '..'));
 };

--- a/packages/axelar-local-dev-near/package.json
+++ b/packages/axelar-local-dev-near/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@axelar-network/axelar-local-dev-near",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "",
     "main": "dist/index.js",
     "files": [
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@axelar-network/axelar-cgp-near": "^1.0.0",
-        "@axelar-network/axelar-local-dev": "2.1.0"
+        "@axelar-network/axelar-local-dev": "2.1.1"
     },
     "author": "",
     "license": "ISC"

--- a/packages/axelar-local-dev-sui/package.json
+++ b/packages/axelar-local-dev-sui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@axelar-network/axelar-local-dev-sui",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "main": "dist/index.js",
     "files": [
         "dist/",
@@ -17,7 +17,7 @@
         "build-sui": "cd move && sui move build"
     },
     "dependencies": {
-        "@axelar-network/axelar-local-dev": "2.1.0",
+        "@axelar-network/axelar-local-dev": "2.1.1",
         "@mysten/sui.js": "^0.41.0"
     },
     "author": "euro@axelar.network",

--- a/packages/axelar-local-dev/package.json
+++ b/packages/axelar-local-dev/package.json
@@ -33,8 +33,9 @@
     },
     "homepage": "https://github.com/axelarnetwork/axelar-local-dev#readme",
     "dependencies": {
-        "@axelar-network/axelar-cgp-solidity": "^5.0.0",
-        "@axelar-network/axelar-gmp-sdk-solidity": "^4.0.2",
+        "@axelar-network/axelar-cgp-solidity": "^6.1.0",
+        "@axelar-network/axelar-chains-config": "^0.1.0",
+        "@axelar-network/axelar-gmp-sdk-solidity": "^5.3.0",
         "ethers": "^5.6.5",
         "fs-extra": "^10.1.0",
         "ganache": "^7.1.0",

--- a/packages/axelar-local-dev/package.json
+++ b/packages/axelar-local-dev/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@axelar-network/axelar-local-dev",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "",
     "main": "dist/index.js",
     "files": [

--- a/packages/axelar-local-dev/src/__tests__/forking.spec.ts
+++ b/packages/axelar-local-dev/src/__tests__/forking.spec.ts
@@ -14,8 +14,7 @@ interface NetworkUsdc extends Network {
     usdc?: Contract;
 }
 
-describe.skip("forking", () => {
-
+describe.skip('forking', () => {
     afterEach(async () => {
         await stopAll();
     });
@@ -24,8 +23,8 @@ describe.skip("forking", () => {
         const chainName = 'Avalanche';
         const tokenAlias = 'uusdc';
         const testAmount = 1234;
-        const chains = mainnetInfo;
-        const avalanche = chains.find((chain: { name: string }) => chain.name === chainName) as any;
+        const chains = mainnetInfo as any;
+        const avalanche = chains[chainName.toLowerCase()];
         const chain: NetworkUsdc = await forkNetwork(avalanche, {
             ganacheOptions: {
                 fork: { deleteCache: true },
@@ -40,11 +39,11 @@ describe.skip("forking", () => {
     });
 
     it('should fork Avalanche and Ethereum and send some USDC back and forth', async () => {
-        const chains = mainnetInfo;
+        const chains = mainnetInfo as any;
         const alias = 'uusdc';
 
         for (const chainName of ['Avalanche', 'Ethereum']) {
-            const chainInfo = chains.find((chain: { name: string }) => chain.name === chainName) as any;
+            const chainInfo = chains[chainName.toLowerCase()];
             const chain = (await forkNetwork(chainInfo)) as any;
             chain.usdc = await chain.getTokenContract(alias);
         }

--- a/packages/axelar-local-dev/src/contracts/index.ts
+++ b/packages/axelar-local-dev/src/contracts/index.ts
@@ -7,8 +7,8 @@ import Auth from '../artifacts/@axelar-network/axelar-cgp-solidity/contracts/aut
 import AxelarGasReceiver from '../artifacts/@axelar-network/axelar-cgp-solidity/contracts/gas-service/AxelarGasService.sol/AxelarGasService.json';
 import AxelarGasReceiverProxy from '../artifacts/@axelar-network/axelar-cgp-solidity/contracts/gas-service/AxelarGasServiceProxy.sol/AxelarGasServiceProxy.json';
 import IAxelarGasService from '../artifacts/@axelar-network/axelar-cgp-solidity/contracts/interfaces/IAxelarGasService.sol/IAxelarGasService.json';
-import ConstAddressDeployer from '@axelar-network/axelar-gmp-sdk-solidity/dist/ConstAddressDeployer.json';
-import Create3Deployer from '@axelar-network/axelar-gmp-sdk-solidity/dist/Create3Deployer.json';
+import ConstAddressDeployer from '@axelar-network/axelar-gmp-sdk-solidity/artifacts/contracts/deploy/ConstAddressDeployer.sol/ConstAddressDeployer.json';
+import Create3Deployer from '@axelar-network/axelar-gmp-sdk-solidity/artifacts/contracts/deploy/Create3Deployer.sol/Create3Deployer.json';
 import IAxelarExecutable from '../artifacts/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarExecutable.sol/IAxelarExecutable.json';
 
 export {

--- a/packages/axelar-local-dev/src/exportUtils.ts
+++ b/packages/axelar-local-dev/src/exportUtils.ts
@@ -5,7 +5,7 @@ import { setJSON } from './utils';
 import { Network, NetworkOptions } from './Network';
 import { RelayData, RelayerMap, relay } from './relay';
 import { createNetwork, forkNetwork, listen, stopAll } from './networkUtils';
-import { testnetInfo, mainnetInfo } from './info';
+import { testnetInfo } from './info';
 import { EvmRelayer } from './relay/EvmRelayer';
 import { getChainArray } from '@axelar-network/axelar-chains-config';
 
@@ -130,7 +130,7 @@ export async function forkAndExport(options: CloneLocalOptions = {}) {
         console.log(`Forking ${_options.env.length} chains from custom data.`);
     }
     const chainsRaw =
-        _options.env == 'mainnet' ? getChainArray(mainnetInfo) : _options.env == 'testnet' ? getChainArray(testnetInfo) : _options.env;
+        _options.env == 'mainnet' ? getChainArray('mainnet') : _options.env == 'testnet' ? getChainArray('testnet') : _options.env;
 
     const chains =
         _options.chains?.length == 0

--- a/packages/axelar-local-dev/src/exportUtils.ts
+++ b/packages/axelar-local-dev/src/exportUtils.ts
@@ -7,6 +7,7 @@ import { RelayData, RelayerMap, relay } from './relay';
 import { createNetwork, forkNetwork, listen, stopAll } from './networkUtils';
 import { testnetInfo, mainnetInfo } from './info';
 import { EvmRelayer } from './relay/EvmRelayer';
+import { getChainArray } from '@axelar-network/axelar-chains-config';
 
 let interval: any;
 
@@ -60,9 +61,7 @@ export async function createAndExport(options: CreateLocalOptions = {}) {
             seed: name,
             ganacheOptions: {},
         });
-        const testnet = testnetInfo.find((info: any) => {
-            return info.name === name;
-        });
+        const testnet = (testnetInfo as any)[name];
         const info = chain.getCloneInfo() as any;
         info.rpc = `http://localhost:${_options.port}/${i}`;
         (info.tokenName = testnet?.tokenName), (info.tokenSymbol = testnet?.tokenSymbol), localChains.push(info);
@@ -130,7 +129,8 @@ export async function forkAndExport(options: CloneLocalOptions = {}) {
     if (_options.env != 'mainnet' && _options.env != 'testnet') {
         console.log(`Forking ${_options.env.length} chains from custom data.`);
     }
-    const chainsRaw = _options.env == 'mainnet' ? mainnetInfo : _options.env == 'testnet' ? testnetInfo : _options.env;
+    const chainsRaw =
+        _options.env == 'mainnet' ? getChainArray(mainnetInfo) : _options.env == 'testnet' ? getChainArray(testnetInfo) : _options.env;
 
     const chains =
         _options.chains?.length == 0

--- a/packages/axelar-local-dev/src/info.ts
+++ b/packages/axelar-local-dev/src/info.ts
@@ -1,7 +1,5 @@
-import testnetInfo from '@axelar-network/axelar-cgp-solidity/info/testnet.json';
-import mainnetInfo from '@axelar-network/axelar-cgp-solidity/info/mainnet.json';
+import mainnet from '@axelar-network/axelar-chains-config/info/mainnet.json';
+import testnet from '@axelar-network/axelar-chains-config/info/testnet.json';
 
-export {
-  testnetInfo,
-  mainnetInfo
-}
+export const mainnetInfo = mainnet.chains;
+export const testnetInfo = testnet.chains;

--- a/packages/axelar-local-dev/tsconfig.json
+++ b/packages/axelar-local-dev/tsconfig.json
@@ -13,7 +13,7 @@
         "declarationMap": true /* Create sourcemaps for d.ts files. */,
         "sourceMap": true /* Create source map files for emitted JavaScript files. */,
         "rootDirs": ["./src", "src/__test__"] /* Specify the root folder within your source files. */,
-        "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+        "outDir": "dist" /* Specify an output folder for all emitted files. */,
 
         /* Interop Constraints */
         // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */


### PR DESCRIPTION
# Description

Closes [AXL-1879](https://axelarnetwork.atlassian.net/browse/AXE-1879?atlOrigin=eyJpIjoiNzA5Y2QwZDAzM2Q0NDEyYzhhMDU4YjdiNDQ3NDk1ZmMiLCJwIjoiaiJ9)

- Bumped axelar-cgp-solidity version from `5.0.0` to `6.1.0` (latest)
- Bumped axelar-gmp-sdk-solidity version from `4.0.2` to `5.3.0` (latest)
- Bumped `axelar-local-dev` from `2.1.0` to `2.1.1`

This PR needs to be tested with [axelar-examples](https://github.com/axelarnetwork/axelar-examples/pull/154) by installing this package locally to ensure compatibility. If everything works, then we can ship this to npm and update the dependency in `axelar-examples`