### PR TITLE
fix in the api_reference.md

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -21,7 +21,7 @@ This module exports the following types:
   - `provider`: The `ethers.Provider` for the network.
   - `userWallets`: A list of funded `ethers.Wallet` objects.
   - `gateway`: An `ethers.Contract` object corresponding to the Axelar Gateway on the network.
-  - `gasReceiver`: An `ethers.Contract` object corresponding to the AxelarGasReceiver that receives gas for remote execution. It expects gas between the same two `relay()`s to funtion properly.
+  - `gasReceiver`: An `ethers.Contract` object corresponding to the AxelarGasReceiver that receives gas for remote execution. It expects gas between the same two `relay()`s to function properly.
   - `ownerWallet`, `operatorWallet`, `relayerWallet`, `adminWallets` `threshold` `lastRelayedBlock`: These are for configuring the gateway and relaying.
   - `deployToken(name, symbol, decimals, cap)`: Deploys a new token on the network. For a token to be supported properly it needs to be deployed on all created networks.
   - `getTokenContract(sybmol)`: Returns an `ethers.Contract` linked to the ERC20 token represented by `symbol`.


### PR DESCRIPTION

Replaced "proccess" with "process" in the sentence: "This is a proccess example."