### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -10,7 +10,7 @@ jobs:
     name: "Publish to NPM"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v3
         with:
           node-version: "16.x"

--- a/.github/workflows/test-aptos.yml
+++ b/.github/workflows/test-aptos.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 18
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/test-cosmos.yml
+++ b/.github/workflows/test-cosmos.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache node_modules
         uses: actions/cache@v3

--- a/.github/workflows/test-evm.yml
+++ b/.github/workflows/test-evm.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache node_modules
         uses: actions/cache@v3

--- a/.github/workflows/test-multiversex.yml
+++ b/.github/workflows/test-multiversex.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 18
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download and Install Multiversx Binary
         run: |

--- a/.github/workflows/test-sui.yml
+++ b/.github/workflows/test-sui.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 18
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache node_modules
         uses: actions/cache@v3


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0